### PR TITLE
Make OP_INVALID to raise ShinkeiResumeWS exception

### DIFF
--- a/shinkei/gateway.py
+++ b/shinkei/gateway.py
@@ -98,7 +98,7 @@ class WSClient(websockets.WebSocketClientProtocol):
             msg = d["error"]
             self._dispatch("error", msg)
 
-            raise ShinkeiWSException(msg)
+            raise ShinkeiResumeWS(msg)
 
         if op == self.OP_DISPATCH:
             self._dispatch("data", MetadataPayload(d))


### PR DESCRIPTION
Shinkei can now reconnect if 신경 raises `heartbeat took too long` error.

## Fixes:
```
Traceback (most recent call last):
  File "/lib/python3.8/site-packages/shinkei/client.py", line 435, in _poll_data
    await self._do_poll()
  File "/lib/python3.8/site-packages/shinkei/client.py", line 416, in _do_poll
    await self._ws.poll_event()
  File "/lib/python3.8/site-packages/shinkei/gateway.py", line 61, in poll_event
    await self.parse_payload(data)
  File "/lib/python3.8/site-packages/shinkei/gateway.py", line 101, in parse_payload
    raise ShinkeiWSException(msg)
shinkei.exceptions.ShinkeiWSException: heartbeat took too long
```